### PR TITLE
added support to django 3.0

### DIFF
--- a/django_sites/utils.py
+++ b/django_sites/utils.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from django.contrib.staticfiles.templatetags.staticfiles import static as _static
+import django
+if django.VERSION[:2] >= (1, 10):
+    from django.templatetags.static import static as _static
+else:
+    from django.contrib.admin.templatetags.admin_static import static as _static
+
 from django.utils.functional import lazy
 
 try:


### PR DESCRIPTION
from django.contrib.admin.templatetags.admin_static import static as _static deprecated in django 3.0